### PR TITLE
Fix version number and spelling of "Shaka Player"

### DIFF
--- a/index.html
+++ b/index.html
@@ -86,11 +86,11 @@
           <!-- <div class="announcement">
             <div class="message">
               <div class="message-text">
-                Themes are tested with 10.0.3 version of Shake player
+                Themes are tested with version 3.0.10 of Shaka player
               </div>
             </div>
           </div> -->
-          <h1 class="page-title">Shake Player Themes</h1>
+          <h1 class="page-title">Shaka Player Themes</h1>
           <section>
 
           


### PR DESCRIPTION
The version number in the comment was inverted (10.0.3 vs 3.0.10) and the name "Shaka" was misspelled as "Shake" twice.